### PR TITLE
Fixes the config file read error (UHD)

### DIFF
--- a/docker/controller/configs/basic_ue_uhd.yaml
+++ b/docker/controller/configs/basic_ue_uhd.yaml
@@ -1,6 +1,6 @@
 processes:
   - type: "srsue"
-    config_file: "../../configs/uhd/ue_uhd.conf"
+    config_file: "configs/uhd/ue_uhd.conf"
 
 data_export:
   output_directory: "/tmp/"


### PR DESCRIPTION
The config path change fixed our previous issue of:

![Screenshot from 2025-01-09 15-29-33](https://github.com/user-attachments/assets/992e34d0-a667-4c04-9d27-cab547b2cc1f)

Now:

![Screenshot from 2025-01-09 15-30-43](https://github.com/user-attachments/assets/be65ce7d-a247-467c-aa3f-e68d6066a651)

(I didn't want to push it directly, thinking this omission might break some other parts of the codebase)